### PR TITLE
Fix the inbound path processing.

### DIFF
--- a/modules/workspaces_negotiator_path/src/PathProcessor.php
+++ b/modules/workspaces_negotiator_path/src/PathProcessor.php
@@ -20,24 +20,27 @@ class PathProcessor implements InboundPathProcessorInterface, OutboundPathProces
   protected $workspaceManager;
 
   /**
+   * @var \Drupal\workspaces_negotiator_path\PathPrefixWorkspaceNegotiator
+   */
+  protected $pathPrefixWorkspaceNegotiator;
+
+  /**
    * PathProcessor constructor.
    */
-  public function __construct(WorkspaceManagerInterface $workspace_manager) {
+  public function __construct(WorkspaceManagerInterface $workspace_manager, PathPrefixWorkspaceNegotiator $path_prefix_workspace_negotiator) {
     $this->workspaceManager = $workspace_manager;
+    $this->pathPrefixWorkspaceNegotiator = $path_prefix_workspace_negotiator;
   }
 
   /**
    * {@inheritdoc}
    */
   public function processInbound($path, Request $request) {
-    $current_workspace = &drupal_static('WorkspacesPathProcessor_active_workspace');
-    if (!isset($current_workspace)) {
-      $current_workspace = $this->workspaceManager->getActiveWorkspace();
-    }
-    if (empty($current_workspace)) {
+    $workspace = $this->pathPrefixWorkspaceNegotiator->getActiveWorkspace($request);
+    if (empty($workspace)) {
       return $path;
     }
-    $path_prefix = $current_workspace->get('path_prefix')->getValue();
+    $path_prefix = $workspace->get('path_prefix')->getValue();
     if (!empty($path_prefix[0]['value']) && $path_prefix[0]['value'] != '/') {
       // Check first if the path prefix of the workspace is really a prefix for
       // the current workspace. Only in that case we will remove the path

--- a/modules/workspaces_negotiator_path/workspaces_negotiator_path.services.yml
+++ b/modules/workspaces_negotiator_path/workspaces_negotiator_path.services.yml
@@ -15,7 +15,7 @@ services:
       # For the outbound processor we want to run at a later stage, so that we
       # can properly prepend the path prefix before other outbound processors.
       - { name: path_processor_outbound, priority: 0 }
-    arguments: ['@workspaces.manager']
+    arguments: ['@workspaces.manager', '@workspaces_negotiator_path.prefix']
   workspaces_negotiator_path.event_subscriber:
     class: Drupal\workspaces_negotiator_path\EventSubscriber\WorkspaceRedirectSubscriber
     arguments: ['@workspaces_negotiator_path.prefix']


### PR DESCRIPTION
When processing an inbound path, we should strip any possible workspace prefix. But currently it strips the workspace prefix only if it matches the prefix of the currently active workspace.

The thing was:
- We do `drush cr` and the following happens:
- It clears route caches.
- Then some menu items pointing to products overview pages are rendered (not sure why, but that's usual with Drupal 😛)
- At this point menu item paths are already prefixed with`/international/en` (again, not sure why)
- The rendering this triggers URL processing and route initialization.
- In the `processInbound` we have a URL starting with `/international`, but the current workspace is Live, so the prefix is not stripped from the path.
- Because of this language prefix is also isn't stripped.
- Drupal tries to find a route for `/international/en/path` rather than for `/path`.
- It finds nothing and caches the zero route result for `/international/en/path`.
- Then we see 404 because of this cache.