### PR TITLE
Skip language restrictions on subrequests

### DIFF
--- a/modules/workspaces_allowed_languages/src/RedirectListener.php
+++ b/modules/workspaces_allowed_languages/src/RedirectListener.php
@@ -65,6 +65,10 @@ class RedirectListener implements EventSubscriberInterface {
    * not match.
    */
   public function onKernelRequest(GetResponseEvent $event) {
+    // Skip any checks for subrequests
+    if (!$event->isMasterRequest()) {
+      return;
+    }
     // Skip any checks if the current user can bypass the workspaces language
     // restrictions.
     if ($this->currentUser->hasPermission('bypass workspaces language restrictions')) {


### PR DESCRIPTION
Hi @pmelab 

Loading a page in a workspace with a non-existing language code might break if there are sub requests.

On nobel we have GraphQL query for block regions in footer `blocksByRegion` that uses sub requests and loading a page in a workspace with non-existing language causes page to break for users that do not have `bypass workspaces language restrictions` permission since sub requests for block also get redirected to 404 page.