### PR TITLE
Fixed reference to non existent batch op method.

### DIFF
--- a/src/Form/DeliveryPushForm.php
+++ b/src/Form/DeliveryPushForm.php
@@ -116,9 +116,6 @@ class DeliveryPushForm extends ConfirmFormBase {
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $batch = [
-      'operations' => [
-        [[$this, 'pushChangesBatch'], [['entity_type' => 'media', 'field_name' => 'media']]],
-      ],
       'finished' => [$this, 'finishPushChanges'],
       'title' => $this->t('Push changes'),
       'progress_message' => $this->t('Pushing changes @current of @total.'),


### PR DESCRIPTION
The method `pushChangesBatch()` no longer exists but is referenced by the batch form, causing a fatal error when pushing a delivery.